### PR TITLE
Making the default icon default blue

### DIFF
--- a/atlasclld/interfaces.py
+++ b/atlasclld/interfaces.py
@@ -42,7 +42,7 @@ class AtlasMapMarker(MapMarker):
 
         else:
             slices = Counter()
-            icon = '#ffffff'
+            icon = '#016acb'
             slices[icon] = 1
             return self.pie(*[(v, k) for k, v in slices.most_common()])
 

--- a/atlasclld/templates/legal.mako
+++ b/atlasclld/templates/legal.mako
@@ -3,12 +3,10 @@
 <h3>Imprint</h3>
 
 <p>
-    This website is part of the online presence of the
-    University of Zurich.
-    More text here.
+    This website is part of the online presence of NCCR Evolving Language. Please refer to the <a href="https://evolvinglanguage.ch/imprint/">corresponding imprint</a> for additional information.
 </p>
 
-<h4>Links to Websites of Third Parties</h4>
+<h4 style="padding-top: 5px; margin-bottom: 5px;">Links to Websites of Third Parties</h4>
 <p>
     This Website includes links to other external websites. These external links are
     designated with an icon as follows:


### PR DESCRIPTION
This change makes the dot on the language detail pages the default blue. Closes #11 