### PR TITLE
Reference sorting, legal changes, emails, appconfig, default blue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This web application is intended to be used with the [ATLAs CLDF data](https://github.com/davidainman/atlas-data/)
+
 Instructions for running the ATLAs CLLD application:
 
 1. Subscribe to the atlas-data repository or download a copy.

--- a/atlasclld/appconf.ini
+++ b/atlasclld/appconf.ini
@@ -3,8 +3,14 @@
 menuitems_list = featuresets features languages contributors references
 
 app_template = atlasclld.mako
+github_repos = davidainman/atlasclld
+github_repos_data = davidainman/atlas-data
 pacific_centered_maps = true
 sitemaps = language feature source featureset contributor
+zenodo_concept_doi = 10.5281/zenodo.14504419
+zenodo_version_doi = 10.5281/zenodo.15224374
+zenodo_version_tag = v2025.1
+dataset_github_repos = davidainman/atlas-data
 
 [mako]
 

--- a/atlasclld/datatables.py
+++ b/atlasclld/datatables.py
@@ -111,6 +111,13 @@ class FeaturesetCol(LinkCol):
         return ATLAsParameter.featureset_pk
 
 
+class AtlasValueNameCol(ValueNameCol):
+    def get_attrs(self, item):
+        label = str(item.value) or 'NO_LABEL'
+        label = HTML.span(map_marker_img(self.dt.req, item), literal('&nbsp;'), label)
+        return {'label': label, 'title': str(item.value)}
+
+
 # personalized tables
 class Features(datatables.Parameters):
     __constraints__ = [ATLAsFeatureSet]
@@ -136,6 +143,7 @@ class Features(datatables.Parameters):
             ),
         ]
 
+
 class Featuresets(datatables.Contributions):
     def col_defs(self):
         return [
@@ -154,13 +162,6 @@ class Languages(datatables.Languages):
             Col(self, "Family", sTitle="Family", model_col=ATLAsLanguage.family_name, sClass="left"),
             Col(self, "Macroarea", model_col=ATLAsLanguage.macroarea, sClass="left"),
         ]
-
-
-class AtlasValueNameCol(ValueNameCol):
-    def get_attrs(self, item):
-        label = str(item.value) or 'NO_LABEL'
-        label = HTML.span(map_marker_img(self.dt.req, item), literal('&nbsp;'), label)
-        return {'label': label, 'title': str(item.value)}
 
 
 class Values(datatables.Values):
@@ -257,6 +258,13 @@ class Contributors(datatables.Contributors):
         return query.filter(common.Contributor.id != 'auto')
 
 
+class Sources(datatables.Sources):
+    def get_options(self):
+        opts = super().get_options()
+        opts['aaSorting'] = [[1, 'asc']]
+        return opts
+
+
 def includeme(config):
     # the name of the datatable must be the same as the name given to the route pattern
     config.register_datatable("values", Values)
@@ -264,3 +272,4 @@ def includeme(config):
     config.register_datatable("parameters", Features)
     config.register_datatable("contributions", Featuresets)
     config.register_datatable("contributors", Contributors)
+    config.register_datatable("sources", Sources)

--- a/atlasclld/templates/contactmail_body.mako
+++ b/atlasclld/templates/contactmail_body.mako
@@ -1,0 +1,11 @@
+% if isinstance(ctx, h.models.ValueSet):
+The coding of ${ctx.language.name} [${ctx.language.id}] for feature ${ctx.parameter.id} (${ctx.parameter.name})
+should be changed from
+"${ctx.values[0].domainelement.description}"
+to
+... (${' or '.join(['"{}"'.format(de.description) for de in ctx.parameter.domain if de != ctx.values[0].domainelement])|n})
+because
+...
+as stated in
+... [source]
+% endif

--- a/atlasclld/templates/contactmail_subject.mako
+++ b/atlasclld/templates/contactmail_subject.mako
@@ -1,0 +1,1 @@
+Issue in ${ctx.id if ctx.id else req.dataset.name}


### PR DESCRIPTION
1. References are sorted by name on loading the references tab
2. Legal page has changed to reflect NCCR imprint, not UZH
3. Email subject and body are fixed
4. appconfig is updated with correct metadata
5. Dots now default to the default blue (this allows language maps to be blue instead of white)

Closes #9, #14 